### PR TITLE
Little fixes to avoid unexpected errors trying to JSON parse response

### DIFF
--- a/Forum/php/index.php
+++ b/Forum/php/index.php
@@ -638,18 +638,18 @@ function api_post($app, $re, $msg_id) {
 
   // retrieve the parameters: 
   $msg = $app->request->getJsonRawBody();
-  
+
+  $subj = $body = $ticket = "";
+  $nsfw = false;
+
   // mandatory
-  $subj = $msg->subject;
-  $body = $msg->body;
-  
+  if (array_key_exists('subject', $msg)) $subj = $msg->subject;
+  if (array_key_exists('body', $msg)) $body = $msg->body;
+
   // optional
-  $nsfw = $msg->nsfw;
-  $ticket = $msg->ticket;
-  
-  if ($ticket == null) $ticket = "";
-  if ($nsfw == null) $nsfw = false;
-  
+  if (array_key_exists('ticket', $msg)) $ticket = $msg->ticket;
+  if (array_key_exists('nsfw', $msg)) $nsfw = $msg->nsfw;
+
   $validation_error = validate($subj, $body);
   if (strlen($validation_error) > 0) {
     


### PR DESCRIPTION
POST /api/threads: more carefully extract passed parameters to avoid ……PHP warnings in responses that break JSON structure. Happens when display_errors = On is set in php.ini.
Example of warning:
<b>Notice</b>:  Trying to get property of non-object in <b>/var/www/kitchen/Forum/php/index.php</b> on line <b>642</b><br />
