### PR TITLE
Make the the second argument in before_bbcode() optional 

### DIFF
--- a/Forum/php/bbcode.php
+++ b/Forum/php/bbcode.php
@@ -106,7 +106,7 @@ function bbcode_naked_urls($str) {
 /** 
  * Run this before bbcode is called to render content before bbcode() had a chance to mess it up
  */
-function before_bbcode($original_body, &$has_video) {
+function before_bbcode($original_body, &$has_video = false) {
   global $host;
   
   $body = preg_replace( array (


### PR DESCRIPTION
to prevent warnings
Warning: Missing argument 2 for before_bbcode(), called in /var/www/kitchen/Forum/php/bbcode.php on line 230 and defined in /var/www/kitchen/Forum/php/bbcode.php on line 109
