### PR TITLE
Fix for Issue #142 "Impossible to change e-mail in user's profile"

### DIFF
--- a/Forum/php/get_params_inc.php
+++ b/Forum/php/get_params_inc.php
@@ -156,6 +156,9 @@
         if (array_key_exists('email', $_POST)) {
             $email = trim($_POST['email']);
         }
+        if (array_key_exists('email1', $_POST)) {
+            $email1 = trim($_POST['email1']);
+        }
         if (array_key_exists('email2', $_POST)) {
             $email2 = trim($_POST['email2']);
         }

--- a/Forum/php/profile_inc.php
+++ b/Forum/php/profile_inc.php
@@ -110,7 +110,7 @@ top.location.reload();
 <td>Leave the fields blank if you <br>don't want to change your password<br><br></td>
 </tr>
 <td align="right">Email</td>
-<td><input id="email" name="email" type="text" maxlength="80" value="<?php print($email); ?>"/></td>
+<td><input id="email1" name="email1" type="text" maxlength="80" value="<?php print($email); ?>"/></td>
 </tr>
 <tr>
 <td align="right">Retype email: </td>

--- a/Forum/php/profile_inc.php
+++ b/Forum/php/profile_inc.php
@@ -109,7 +109,7 @@ top.location.reload();
 <td></td>
 <td>Leave the fields blank if you <br>don't want to change your password<br><br></td>
 </tr>
-<td align="right">Email</td>
+<td align="right">Email: </td>
 <td><input id="email1" name="email1" type="text" maxlength="80" value="<?php print($email); ?>"/></td>
 </tr>
 <tr>

--- a/Forum/php/update.php
+++ b/Forum/php/update.php
@@ -31,7 +31,7 @@ require_once('html_head_inc.php');
                     $update = ' password=password(\'' . $password . '\')';
                 } 
             }
-            if (is_null($email) || strlen($email) == 0) {
+            if (is_null($email1) || strlen($email1) == 0) {
                 if (strlen($update) == 0) {
                     $err = 'At least one - email or password should be populated for the update';
                     break;
@@ -41,18 +41,18 @@ require_once('html_head_inc.php');
                     $err = 'Please, retype email';
                     break;
                 }
-                if (strcmp($email, $email2)) {
+                if (strcmp($email1, $email2)) {
                     $err = 'Email does not match';
                     break; 
                 }
-                $err = validateEmail($email);
+                $err = validateEmail($email1);
                 if (strlen($err) > 0 ){
                     break;
                 }
                 if (strlen($update) > 0) {
                     $update .= ', ';
                 }
-                $update .= 'email=\'' . mysql_real_escape_string( $email ). '\' ';
+                $update .= 'email=\'' . mysql_real_escape_string( $email1 ). '\' ';
             }
             if (strlen($update) > 0) {
                 $update .= ', ';


### PR DESCRIPTION
$email submitted via <form>'s POST is always overwritten by $email taken from DB for given user due to including auth.php after get_params_inc.php: https://github.com/wolfpet/kitchen/blob/250f5eddf2efa6222cc2a8b1e68de557d1a6e730/Forum/php/head_inc.php#L169

I think changing the order of require_once() is rather dangerous so decided to change the input's name in this form from $email to $email1.